### PR TITLE
Use car instead of first for byte-compile warning

### DIFF
--- a/projectile-direnv.el
+++ b/projectile-direnv.el
@@ -42,7 +42,7 @@
   "Parses a single line of the form export VAR=VAL into a cons
 cell where the car is the var name and the cdr is its value."
   (let* ((parts (s-split "=" line))
-         (varname (car (last (s-split " " (first parts)))))
+         (varname (car (last (s-split " " (car parts)))))
          (varval (car (last parts))))
     (cons varname varval)))
 


### PR DESCRIPTION
There is a following byte-compile warning.

```
projectile-direnv.el:81:1:Warning: the function ‘first’ is not known to be defined.
```

`first` is defined in `cl.el`. So it is necessary to load `cl.el` for using it. Or load `cl-lib.el` and use `cl-first` instead of it.
